### PR TITLE
Fix error 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ When clicked, the image is replaced by the embed iframe showing the model in the
 
 ## Installation
 
+1. Install [discourse](https://github.com/discourse/discourse/blob/master/docs/DEVELOPER-ADVANCED.md).
+
+2. Execute in the `discourse` root directory:
+
 ```bash
 rake plugin:install repo=https://github.com/Aerilius/discourse-sketchup-3dwh-onebox.git name=sketchup_3dwh_onebox
 rake assets:precompile

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,9 +19,20 @@ module Onebox
       end
 
       BASE_URL = "https://3dwarehouse.sketchup.com"
-      # Matches details page (model.html?id=) and embed codes (embed.html?mid=)
-      # for old 32 digit hexadecimal id and new uuid.
-      REGEX = /^(?:https?:\/\/)3dwarehouse\.sketchup\.com\/(?:model\.html\?id=|embed\.html\?mid=)([a-fA-F0-9]{32}|[uU]?[a-fA-F0-9\-]{36})\S*$/
+      # Matcher for model details url and embed url.
+      REGEX = /^(?:https?:\/\/)             # http or https
+               3dwarehouse\.sketchup\.com\/ # domain
+               (?:
+                 model\.html\?id=           # old model details page
+                |embed\.html\?mid=          # old embed code
+                |model\/                    # new model details path
+               )
+               (
+                 [a-fA-F0-9]{32}            # old (Google era) model id
+                |[uU]?[a-fA-F0-9\-]{36}     # uuid prefixed with 'u' or new uuid not prefixed
+               )
+               \S*$/x                       # anything following that is not a space
+               # x ignores whitespace in multiline regexp
 
       THUMB_PRIORITY_ORDER = %w(bot_lt lt bot_st st)
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -21,7 +21,7 @@ module Onebox
       BASE_URL = "https://3dwarehouse.sketchup.com"
       # Matches details page (model.html?id=) and embed codes (embed.html?mid=)
       # for old 32 digit hexadecimal id and new uuid.
-      REGEX = /^(?:https?:\/\/)3dwarehouse.sketchup\.com\/(?:model\.html\?id=|embed\.html\?mid=)([a-fA-F0-9]{32}|[uU][a-fA-F0-9\-]{36})\S*$/
+      REGEX = /^(?:https?:\/\/)3dwarehouse\.sketchup\.com\/(?:model\.html\?id=|embed\.html\?mid=)([a-fA-F0-9]{32}|[uU][a-fA-F0-9\-]{36})\S*$/
 
       # Register the regular expression for testing if the onebox handles a certain link:
       matches_regexp REGEX

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: sketchup_3dwh_onebox
 # about: Discourse plugin for embedding SketchUp 3D Warehouse models in a onebox
-# version: 0.1
+# version: 0.2
 # authors: Andreas Eisenbarth
 
 register_asset "stylesheets/sketchup_3dwh_onebox.css"
@@ -21,7 +21,7 @@ module Onebox
       BASE_URL = "https://3dwarehouse.sketchup.com"
       # Matches details page (model.html?id=) and embed codes (embed.html?mid=)
       # for old 32 digit hexadecimal id and new uuid.
-      REGEX = /^(?:https?:\/\/)3dwarehouse\.sketchup\.com\/(?:model\.html\?id=|embed\.html\?mid=)([a-fA-F0-9]{32}|[uU][a-fA-F0-9\-]{36})\S*$/
+      REGEX = /^(?:https?:\/\/)3dwarehouse\.sketchup\.com\/(?:model\.html\?id=|embed\.html\?mid=)([a-fA-F0-9]{32}|[uU]?[a-fA-F0-9\-]{36})\S*$/
 
       THUMB_PRIORITY_ORDER = %w(bot_lt lt bot_st st)
 


### PR DESCRIPTION
For some urls, the onebox was not generated anymore, instead, the browser console showed a 404 error:

https://3dwarehouse.sketchup.com/model.html?id=a745c0ce-67bd-4cc6-b6c0-f65949915d6e

```
GET http://forums.sketchup.com/onebox?url=https%3A%2F%2F3dwarehouse.sketchup.com%2Fmodel.html%3Fid%3Da745c0ce-67bd-4cc6-b6c0-f65949915d6e&refresh=true 404 (Not Found)
```

The error was thrown by discourse not finding a matching onebox (see comment in `discourse/app/controllers/onebox_controller.rb:10`). It seems the 3D Warehouse url `id` parameter omits since some time the `u` in front of the new longer IDs so that the regular expression did not match anymore.

As a solution I made the `[uU]` optional.