### PR TITLE
Update onebox size to match current embedding size

### DIFF
--- a/assets/stylesheets/sketchup_3dwh_onebox.css
+++ b/assets/stylesheets/sketchup_3dwh_onebox.css
@@ -1,6 +1,6 @@
 .onebox-3dwh {
-  width: 400px;
-  height: 300px;
+  width: 580px;
+  height: 326px;
   position: relative; /* so that we can use 'absolute' inside */
   border: 1px solid #E9E9E9; /* to make it visible while it is loading */
 }

--- a/plugin.rb
+++ b/plugin.rb
@@ -40,8 +40,8 @@ module Onebox
       matches_regexp REGEX
 
       def placeholder_html
-        w = 400
-        h = 300
+        w = 580
+        h = 326
         id = @url.match(REGEX)[1]
         request_url = "#{BASE_URL}/3dw/GetEntity?id=#{id}"
 
@@ -68,8 +68,8 @@ HTML
       # Since 3D Warehouse does not give links to images, we use an iframe for
       # both static image and 3d view.
       def to_html
-        w = 400
-        h = 300
+        w = 580
+        h = 326
         id = @url.match(REGEX)[1]
         embed_image = "#{BASE_URL}/embed.html?mid=#{id}&width=#{w}&height=#{h}&etp=im"
         embed_3d = "#{BASE_URL}/embed.html?mid=#{id}&width=#{w}&height=#{h}"


### PR DESCRIPTION
Thumbnails were shown vertically stretched since aspect ratio changed when 3D Warehouse increased the  embed sizes from 400×300 to 580×326.